### PR TITLE
Metadata Enhancements

### DIFF
--- a/metalus-application/pom.xml
+++ b/metalus-application/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>metalus</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/metalus-aws/pom.xml
+++ b/metalus-aws/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>metalus</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/metalus-common/pom.xml
+++ b/metalus-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>metalus</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/metalus-common/pom.xml
+++ b/metalus-common/pom.xml
@@ -17,6 +17,7 @@
             <groupId>com.acxiom</groupId>
             <artifactId>metalus-core_${scala.compat.version}-spark_${spark.compat.version}</artifactId>
             <version>${parent.version}</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Test -->
         <dependency>

--- a/metalus-core/docs/application.md
+++ b/metalus-core/docs/application.md
@@ -234,7 +234,13 @@ A list of pipelines definitions that can be referenced in any defined execution.
     }
   ]
  }
-``` 
+```
+
+### pipelineManager
+The PipelineManager is used to perform lookups on pipelines for step groups and during execution setup. When overriding
+this class, be aware that when executions are being constructed, the execution pipelines will be used, then the application
+pipelines and finally the PipelineManager will be used. One note when *pipelineIds* is present, then the execution pipelines
+will be skipped.
 
 ### globals
 The globals object will be merged with the application parameters passed to the 'spark-submit' command. All elements are

--- a/metalus-core/pom.xml
+++ b/metalus-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>metalus</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineExecutor.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineExecutor.scala
@@ -52,6 +52,10 @@ object PipelineExecutor {
       val exCtx = ctx.setRootAudit(ctx.rootAudit.setEnd(System.currentTimeMillis()))
       PipelineExecutionResult(handleEvent(exCtx, "executionFinished", List(executingPipelines, exCtx)), success = true)
     } catch {
+      case fe: ForkedPipelineStepException =>
+        fe.exceptions.foreach(entry =>
+          logger.error(s"Execution Id ${entry._1} had an error: ${entry._2.getMessage}", entry._2))
+        PipelineExecutionResult(esContext, success = false)
       case p: PauseException =>
         logger.info(s"Paused pipeline flow at pipeline ${p.pipelineId} step ${p.stepId}. ${p.message}")
         PipelineExecutionResult(esContext, success = false)

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineExecutor.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineExecutor.scala
@@ -215,8 +215,8 @@ object PipelineExecutor {
     val pipelineId = pipelineContext.getGlobalString("pipelineId").getOrElse("")
     val groupId = pipelineContext.getGlobalString("groupId")
     val ctx = step match {
-      case PipelineStep(_, _, _, Some("fork"), _, _, _, _) => result.asInstanceOf[ForkStepResult].pipelineContext
-      case PipelineStep(_, _, _, Some(STEPGROUP), _, _, _, _) =>
+      case PipelineStep(_, _, _, Some("fork"), _, _, _, _, _) => result.asInstanceOf[ForkStepResult].pipelineContext
+      case PipelineStep(_, _, _, Some(STEPGROUP), _, _, _, _, _) =>
         val groupResult = result.asInstanceOf[StepGroupResult]
         val updatedCtx = pipelineContext.setStepAudit(pipelineId, groupResult.audit)
           .setParameterByPipelineId(pipelineId, step.id.getOrElse(""), groupResult.pipelineStepResponse)
@@ -271,7 +271,7 @@ object PipelineExecutor {
 
   private def getNextStepId(step: PipelineStep, result: Any): Option[String] = {
     step match {
-      case PipelineStep(_, _, _, Some("branch"), _, _, _, _) =>
+      case PipelineStep(_, _, _, Some("branch"), _, _, _, _, _) =>
         // match the result against the step parameter name until we find a match
         val matchValue = result match {
           case response: PipelineStepResponse => response.primaryReturn.getOrElse("").toString
@@ -284,7 +284,7 @@ object PipelineExecutor {
         } else {
           None
         }
-      case PipelineStep(_, _, _, Some("fork"), _, _, _, _) => result.asInstanceOf[ForkStepResult].nextStepId
+      case PipelineStep(_, _, _, Some("fork"), _, _, _, _, _) => result.asInstanceOf[ForkStepResult].nextStepId
       case _ => step.nextStepId
     }
   }

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineManager.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineManager.scala
@@ -1,12 +1,26 @@
 package com.acxiom.pipeline
 
+import com.acxiom.pipeline.utils.DriverUtils
+
+import scala.io.Source
+
 object PipelineManager {
   def apply(pipelines: List[Pipeline]): PipelineManager = new CachedPipelineManager(pipelines)
 }
 
 trait PipelineManager {
   def getPipeline(id: String): Option[Pipeline] = {
-    None
+    val input = getClass.getClassLoader.getResourceAsStream(s"metadata/pipelines/$id.json")
+    if (Option(input).isDefined) {
+      val pipelineList = DriverUtils.parsePipelineJson(Source.fromInputStream(input).mkString)
+      if (pipelineList.isDefined && pipelineList.get.nonEmpty) {
+        Some(pipelineList.get.head)
+      } else {
+        None
+      }
+    } else {
+      None
+    }
   }
 }
 

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineStep.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/PipelineStep.scala
@@ -15,6 +15,7 @@ import com.acxiom.pipeline.PipelineStepMessageType.PipelineStepMessageType
   * @param engineMeta     Contains the instruction for invoking the step function.
   * @param executeIfEmpty This field allows a value to be passed in rather than executing the step.
   * @param nextStepId     The id of the next step to execute.
+  * @param stepId         The id of the step that provided the metadata.
   */
 case class PipelineStep(id: Option[String] = None,
                         displayName: Option[String] = None,
@@ -23,7 +24,8 @@ case class PipelineStep(id: Option[String] = None,
                         params: Option[List[Parameter]] = None,
                         engineMeta: Option[EngineMeta] = None,
                         nextStepId: Option[String] = None,
-                        executeIfEmpty: Option[String] = None)
+                        executeIfEmpty: Option[String] = None,
+                        stepId: Option[String] = None)
 
 /**
   * Represents a single parameter in a step.

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/api/HttpRestClient.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/api/HttpRestClient.scala
@@ -57,8 +57,7 @@ class HttpRestClient(hostUrl: String, authorization: Option[Authorization]) {
     * @return True if the path exists, otherwise false.
     */
   def exists(path: String): Boolean = {
-    val contentType = this.openUrlConnection(path).getContentType
-    Option(contentType).isDefined
+    this.openUrlConnection(path).getResponseCode != 404
   }
 
   /**
@@ -94,6 +93,28 @@ class HttpRestClient(hostUrl: String, authorization: Option[Authorization]) {
     */
   def getStringContent(path: String): String = {
     val input = getInputStream(path)
+    val content = Source.fromInputStream(input).mkString
+    input.close()
+    content
+  }
+
+  /**
+    * Simple method to post string content.
+    * @param path The path to post the content
+    * @param body The body to post
+    * @param contentType The content type to post. Defaults to JSON.
+    * @return The String output of the command.
+    */
+  def postJsonContent(path: String, body: String, contentType: String = "application/json"): String = {
+    val connection = this.openUrlConnection(path)
+    connection.setDoOutput(true)
+    connection.setRequestProperty("Content-Type", contentType)
+    connection.setRequestMethod("POST")
+    val output = connection.getOutputStream
+    output.write(body.getBytes, 0, body.length)
+    output.flush()
+    output.close()
+    val input = connection.getInputStream
     val content = Source.fromInputStream(input).mkString
     input.close()
     content

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/applications/ApplicationDriverSetup.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/applications/ApplicationDriverSetup.scala
@@ -18,17 +18,7 @@ trait ApplicationDriverSetup extends DriverSetup {
     } else if (parameters.contains("applicationConfigPath")) {
       val path = parameters("applicationConfigPath").toString
       if (path.startsWith("http")) {
-        val authorizationClass = "authorization.class"
-        if (parameters.contains(authorizationClass)) {
-          val authorizationParameters = parameters.filter(entry =>
-            entry._1.startsWith("authorization.") && entry._1 != authorizationClass)
-            .map(entry => entry._1.substring("authorization.".length) -> entry._2)
-          HttpRestClient(path,
-            ReflectionUtils.loadClass(parameters(authorizationClass).asInstanceOf[String], Some(authorizationParameters))
-              .asInstanceOf[Authorization]).getStringContent("")
-        } else {
-          HttpRestClient(path).getStringContent("")
-        }
+        DriverUtils.getHttpRestClient(path, parameters).getStringContent("")
       } else {
         val className = parameters.getOrElse("applicationConfigurationLoader", "com.acxiom.pipeline.fs.LocalFileManager").asInstanceOf[String]
         DriverUtils.loadJsonFromFile(path, className, parameters)

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/applications/ApplicationUtils.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/applications/ApplicationUtils.scala
@@ -120,8 +120,11 @@ object ApplicationUtils {
     val applicationPipelines = application.pipelines.getOrElse(List[Pipeline]())
 
     if (pipelineIds.nonEmpty) {
+      // Start with any pipelines that are part of the execution and listed in the pipelineIds
       val filteredExecutionPipelines = executionPipelines.filter(p => pipelineIds.contains(p.id.getOrElse("")))
-      pipelineIds.foldLeft(filteredExecutionPipelines)((pipelines, pipelineId) => {
+      // Get the remaining pipelines listed in pipelineIds
+      pipelineIds.filter(id => !filteredExecutionPipelines.exists(_.id.getOrElse("") == id))
+        .foldLeft(filteredExecutionPipelines)((pipelines, pipelineId) => {
         val pipeline = applicationPipelines.find(p => p.id.getOrElse("") == pipelineId)
         if (pipeline.isDefined) {
           pipelines :+ pipeline.get
@@ -134,10 +137,6 @@ object ApplicationUtils {
           }
         }
       })
-      filteredExecutionPipelines ++ applicationPipelines
-        .filter(p => {
-          !filteredExecutionPipelines.exists(e => e.id.getOrElse("") == p.id.getOrElse("")) && pipelineIds.contains(p.id.get)
-        })
     } else if (executionPipelines.nonEmpty) {
       executionPipelines
     } else if (applicationPipelines.nonEmpty) {

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/utils/DriverUtils.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/utils/DriverUtils.scala
@@ -2,6 +2,7 @@ package com.acxiom.pipeline.utils
 
 import java.text.ParseException
 
+import com.acxiom.pipeline.api.{Authorization, HttpRestClient}
 import com.acxiom.pipeline.fs.FileManager
 import com.acxiom.pipeline.{DefaultPipeline, Pipeline, PipelineExecution}
 import org.apache.hadoop.io.LongWritable
@@ -77,6 +78,20 @@ object DriverUtils {
     })
     validateRequiredParameters(parameters, requiredParameters)
     parameters
+  }
+
+  def getHttpRestClient(url: String, parameters: Map[String, Any]): HttpRestClient = {
+    val authorizationClass = "authorization.class"
+    if (parameters.contains(authorizationClass)) {
+      val authorizationParameters = parameters.filter(entry =>
+        entry._1.startsWith("authorization.") && entry._1 != authorizationClass)
+        .map(entry => entry._1.substring("authorization.".length) -> entry._2)
+      HttpRestClient(url,
+        ReflectionUtils.loadClass(parameters(authorizationClass).asInstanceOf[String], Some(authorizationParameters))
+          .asInstanceOf[Authorization])
+    } else {
+      HttpRestClient(url)
+    }
   }
 
   /**

--- a/metalus-core/src/main/scala/com/acxiom/pipeline/utils/DriverUtils.scala
+++ b/metalus-core/src/main/scala/com/acxiom/pipeline/utils/DriverUtils.scala
@@ -1,7 +1,5 @@
 package com.acxiom.pipeline.utils
 
-import java.text.ParseException
-
 import com.acxiom.pipeline.api.{Authorization, HttpRestClient}
 import com.acxiom.pipeline.fs.FileManager
 import com.acxiom.pipeline.{DefaultPipeline, Pipeline, PipelineExecution}
@@ -118,10 +116,12 @@ object DriverUtils {
     */
   def parsePipelineJson(pipelineJson: String): Option[List[Pipeline]] = {
     implicit val formats: Formats = DefaultFormats
-    if (pipelineJson.trim()(0) != '[') {
-      throw new ParseException(pipelineJson, 0)
+    val json = if (pipelineJson.nonEmpty && pipelineJson.trim()(0) != '[') {
+      s"[$pipelineJson]"
+    } else {
+      pipelineJson
     }
-    parse(pipelineJson).extractOpt[List[DefaultPipeline]]
+    parse(json).extractOpt[List[DefaultPipeline]]
   }
 
   /**

--- a/metalus-core/src/test/resources/application-test.json
+++ b/metalus-core/src/test/resources/application-test.json
@@ -170,7 +170,7 @@
   "executions": [
     {
       "id": "0",
-      "pipelineIds": ["Pipeline1"],
+      "pipelineIds": ["9ecbaee7-ba8d-4520-815b-e5e5a24b1872"],
       "securityManager": {
         "className": "com.acxiom.pipeline.applications.TestPipelineSecurityManager",
         "parameters": {

--- a/metalus-core/src/test/resources/metadata/pipelines/9ecbaee7-ba8d-4520-815b-e5e5a24b1872.json
+++ b/metalus-core/src/test/resources/metadata/pipelines/9ecbaee7-ba8d-4520-815b-e5e5a24b1872.json
@@ -1,0 +1,22 @@
+{
+  "id": "9ecbaee7-ba8d-4520-815b-e5e5a24b1872",
+  "name": "Pipeline 1",
+  "steps": [
+    {
+      "id": "Pipeline1Step1",
+      "displayName": "Pipeline1Step1",
+      "type": "pipeline",
+      "params": [
+        {
+          "type": "text",
+          "name": "value",
+          "required": true,
+          "value": "Chain0"
+        }
+      ],
+      "engineMeta": {
+        "spark": "ExecutionSteps.normalFunction"
+      }
+    }
+  ]
+}

--- a/metalus-core/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
+++ b/metalus-core/src/test/scala/com/acxiom/pipeline/MockStepObject.scala
@@ -54,6 +54,11 @@ class MockNoParams {
   def string: String = "no-constructor-string"
 }
 
+class MockDefaultParam(flag: Boolean = false, secondParam: String = "none") {
+  def getFlag: Boolean = flag
+  def getSecondParam: String = secondParam
+}
+
 case class MockDriverSetup(parameters: Map[String, Any]) extends DriverSetup {
   override def pipelines: List[Pipeline] = List()
 

--- a/metalus-core/src/test/scala/com/acxiom/pipeline/PipelineManagerTests.scala
+++ b/metalus-core/src/test/scala/com/acxiom/pipeline/PipelineManagerTests.scala
@@ -1,0 +1,29 @@
+package com.acxiom.pipeline
+
+import org.scalatest.{FunSpec, Suite}
+
+class PipelineManagerTests extends FunSpec with Suite {
+  describe("PipelineManager - Get Tests") {
+    it("Should fetch cached pipeline") {
+      val pm = PipelineManager(List(Pipeline(Some("pipeline"), Some("Test pipeline"))))
+      assert(pm.getPipeline("pipeline").isDefined)
+      assert(pm.getPipeline("pipeline").get.name.getOrElse("") == "Test pipeline")
+    }
+
+    it("Should fail to return a pipeline") {
+      val pm = PipelineManager(List(Pipeline(Some("pipeline"), Some("Test pipeline"))))
+      assert(pm.getPipeline("fred").isEmpty)
+      assert(pm.getPipeline("bad").isEmpty)
+    }
+
+    it("Should pull a pipeline from the classpath") {
+      val pm = PipelineManager(List(Pipeline(Some("pipeline"), Some("Test pipeline"))))
+      val pipeline = pm.getPipeline("9ecbaee7-ba8d-4520-815b-e5e5a24b1872")
+      assert(pipeline.isDefined)
+      assert(pipeline.get.name.getOrElse("") == "Pipeline 1")
+      assert(pipeline.get.steps.isDefined)
+      assert(pipeline.get.steps.get.length == 1)
+      assert(pipeline.get.steps.get.head.id.getOrElse("") == "Pipeline1Step1")
+    }
+  }
+}

--- a/metalus-core/src/test/scala/com/acxiom/pipeline/api/HttpRestClientTests.scala
+++ b/metalus-core/src/test/scala/com/acxiom/pipeline/api/HttpRestClientTests.scala
@@ -54,6 +54,13 @@ class HttpRestClientTests extends FunSpec with BeforeAndAfterAll with Suite {
       assert(content == "this is some content")
       assert(http.getStringContent("/files/testFile") == "this is some content")
 
+      wireMockServer.addStubMapping(post(urlPathEqualTo("/files"))
+      .withBasicAuth("myuser", "mypassword")
+      .withRequestBody(equalTo("{body: {} }"))
+        .willReturn(aResponse()
+          .withBody("this is some returned content")).build())
+      assert(http.postJsonContent("/files", "{body: {} }") == "this is some returned content")
+
       wireMockServer.addStubMapping(delete(urlPathEqualTo("/files/deleteFile"))
         .withBasicAuth("myuser", "mypassword")
         .willReturn(aResponse().withStatus(HttpURLConnection.HTTP_NO_CONTENT)).build())

--- a/metalus-core/src/test/scala/com/acxiom/pipeline/utils/DriverUtilsTests.scala
+++ b/metalus-core/src/test/scala/com/acxiom/pipeline/utils/DriverUtilsTests.scala
@@ -29,15 +29,6 @@ class DriverUtilsTests extends FunSpec {
   describe("DriverUtils - parsePipelineJson") {
     implicit val formats: Formats = DefaultFormats
 
-    it("Should throw an exception when the json is not valid") {
-      val json = s"""{"id": "1"}"""
-      val thrown = intercept[ParseException] {
-        DriverUtils.parsePipelineJson(json)
-      }
-      assert(thrown.getMessage.contains(json))
-      assert(thrown.getErrorOffset == 0)
-    }
-
     it("Should parse a basic pipeline json returning a list of Pipeline objects") {
       val json = Serialization.write(PipelineDefs.TWO_PIPELINE)
       val pipelineList = DriverUtils.parsePipelineJson(json)
@@ -45,13 +36,6 @@ class DriverUtilsTests extends FunSpec {
       assert(pipelineList.get.lengthCompare(2) == 0)
       verifyParsedPipelines(pipelineList.get.head, PipelineDefs.TWO_PIPELINE.head)
       verifyParsedPipelines(pipelineList.get(1), PipelineDefs.TWO_PIPELINE(1))
-    }
-
-    it("Should throw and error when json is invalid") {
-      val thrown = intercept[RuntimeException] {
-        DriverUtils.parsePipelineJson("")
-      }
-      assert(Option(thrown).isDefined)
     }
 
     def verifyParsedPipelines(pipeline1: Pipeline, pipeline2: Pipeline): Unit = {

--- a/metalus-core/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
+++ b/metalus-core/src/test/scala/com/acxiom/pipeline/utils/ReflectionUtilsTests.scala
@@ -80,7 +80,7 @@ class ReflectionUtilsTests extends FunSpec {
       val step = PipelineStep(None, None, None, None, None,
         Some(EngineMeta(Some("MockStepObject.typo"))))
       val thrown = intercept[IllegalArgumentException] {
-        val response = ReflectionUtils.processStep(step, pipeline, Map[String, Any](), pipelineContext)
+        ReflectionUtils.processStep(step, pipeline, Map[String, Any](), pipelineContext)
       }
       assert(thrown.getMessage == "typo is not a valid function!")
     }
@@ -143,9 +143,36 @@ class ReflectionUtilsTests extends FunSpec {
 
     it("Should instantiate no param constructor") {
       val className = "com.acxiom.pipeline.MockNoParams"
-      val mc = ReflectionUtils.loadClass(className, None)
+      val mc = ReflectionUtils.loadClass(className, Some(Map[String, Any]("test" -> true)))
       assert(mc.isInstanceOf[MockNoParams])
       assert(mc.asInstanceOf[MockNoParams].string == "no-constructor-string")
+
+      val mc1 = ReflectionUtils.loadClass(className, None)
+      assert(mc1.isInstanceOf[MockNoParams])
+      assert(mc1.asInstanceOf[MockNoParams].string == "no-constructor-string")
+    }
+
+    it("Should instantiate default param constructor") {
+      val className = "com.acxiom.pipeline.MockDefaultParam"
+      val mc = ReflectionUtils.loadClass(className, Some(Map[String, Any]("test" -> true)))
+      assert(mc.isInstanceOf[MockDefaultParam])
+      assert(!mc.asInstanceOf[MockDefaultParam].getFlag)
+      assert(mc.asInstanceOf[MockDefaultParam].getSecondParam == "none")
+
+      val mc1  = ReflectionUtils.loadClass(className, Some(Map[String, Any]("flag" -> true)))
+      assert(mc1.isInstanceOf[MockDefaultParam])
+      assert(mc1.asInstanceOf[MockDefaultParam].getFlag)
+      assert(mc1.asInstanceOf[MockDefaultParam].getSecondParam == "none")
+
+      val mc2  = ReflectionUtils.loadClass(className, None)
+      assert(mc2.isInstanceOf[MockDefaultParam])
+      assert(!mc2.asInstanceOf[MockDefaultParam].getFlag)
+      assert(mc2.asInstanceOf[MockDefaultParam].getSecondParam == "none")
+
+      val mc3  = ReflectionUtils.loadClass(className, Some(Map[String, Any]("secondParam" -> "some")))
+      assert(mc3.isInstanceOf[MockDefaultParam])
+      assert(!mc3.asInstanceOf[MockDefaultParam].getFlag)
+      assert(mc3.asInstanceOf[MockDefaultParam].getSecondParam == "some")
     }
   }
 

--- a/metalus-examples/pom.xml
+++ b/metalus-examples/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>metalus</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/metalus-utils/assembly.xml
+++ b/metalus-utils/assembly.xml
@@ -7,7 +7,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <files>
         <file>
-            <source>step-metadata-extractor.sh</source>
+            <source>metadata-extractor.sh</source>
             <outputDirectory>metalus-utils/bin</outputDirectory>
         </file>
     </files>

--- a/metalus-utils/metadata-extractor.sh
+++ b/metalus-utils/metadata-extractor.sh
@@ -3,19 +3,22 @@
 usage()
 {
 	echo "step-metadata-extractor.sh [OPTIONS]"
-	echo "--step-packages -> A comma separated list of packages to scan"
-	echo "--output-file   -> A file name to write the JSON output. This parameter is optional."
+	echo "--output-path   -> A path to write the JSON output. This parameter is optional."
+	echo "--api-url       -> The base URL to use when pushing data to an API. This parameter is optional."
 	echo "--jar-files     -> A comma separated list of jar files to scan"
 }
 
 # Parse the parameters
 while [[ "$1" != "" ]]; do
     case $1 in
-        --step-packages )       shift
-                                stepPackages=$1
+        --output-path )    		shift
+        						outputPath=$1
                                 ;;
-        --output-file )    		shift
-        						outputFile=$1
+        --api-url )           shift
+                    apiUrl=$1
+                                ;;
+        --extractors )        shift
+                    extractors=$1
                                 ;;
         --jar-files )           shift
         						jarFiles=$1
@@ -44,11 +47,21 @@ do
     classPath="${classPath}:${i}"
 done
 
-params="--step-packages ${stepPackages} --jar-files ${jarFiles}"
+params="--jar-files ${jarFiles}"
 
-if [[ -n "${outputFile}" ]]
+if [[ -n "${outputPath}" ]]
 then
-	params="${params} --output-file ${outputFile}"
+	params="${params} --output-path ${outputPath}"
 fi
 
-exec scala -cp ${classPath} com.acxiom.pipeline.annotations.StepMetaDataExtractor ${params}
+if [[ -n "${apiUrl}" ]]
+then
+  params="${params} --api-url ${apiUrl}"
+fi
+
+if [[ -n "${extractors}" ]]
+then
+  params="${params} --extractors ${extractors}"
+fi
+
+exec scala -cp ${classPath} com.acxiom.pipeline.MetadataExtractor ${params}

--- a/metalus-utils/metadata-extractor.sh
+++ b/metalus-utils/metadata-extractor.sh
@@ -64,4 +64,4 @@ then
   params="${params} --extractors ${extractors}"
 fi
 
-exec scala -cp ${classPath} com.acxiom.pipeline.MetadataExtractor ${params}
+exec scala -cp ${classPath} com.acxiom.metalus.MetadataExtractor ${params}

--- a/metalus-utils/pom.xml
+++ b/metalus-utils/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.acxiom</groupId>
         <artifactId>metalus</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/metalus-utils/readme.md
+++ b/metalus-utils/readme.md
@@ -4,7 +4,8 @@ Application utilities are provided as a way to make working with the project eas
 ## Metadata Extractor
 The MetadataExtractor is a generic tool which will scan the provided jar files and extract specific metadata. The 
 StepMetadataExtractor and PipelineMetadataExtractor will be executed by default and additional extractors can be 
-executed as long as the classes are part of the provided jars and implement the **Extractor** trait. 
+executed as long as the classes are part of the provided jars and implement the **Extractor** trait. The default extractors
+can be disabled by setting the flags *excludePipelines* and *excludeSteps* to true.
 
 ### Step Metadata Extractor
 This extractor will scan jar files that contain steps and produce a JSON representation. The tool takes a list of packages

--- a/metalus-utils/readme.md
+++ b/metalus-utils/readme.md
@@ -3,8 +3,8 @@ Application utilities are provided as a way to make working with the project eas
 
 ## Metadata Extractor
 The MetadataExtractor is a generic tool which will scan the provided jar files and extract specific metadata. The 
-StepMetadataExtractor executed by default and additional extractors can be executed as long as the classes are part of
-the provided jars and implement the **Extractor** trait. 
+StepMetadataExtractor and PipelineMetadataExtractor will be executed by default and additional extractors can be 
+executed as long as the classes are part of the provided jars and implement the **Extractor** trait. 
 
 ### Step Metadata Extractor
 This extractor will scan jar files that contain steps and produce a JSON representation. The tool takes a list of packages
@@ -24,6 +24,11 @@ parameters in each step.
 
 **Note:** When using annotations, all parameters must be supplied. Named parameters will not work.
 
+### Pipeline Metadata Extractor
+This extractor will scan jar files looking for JSON files stored under the *metadata/pipelines* path. Each pipeline will
+be loaded and reconciled to a list. This list will be written to the *pipelines.json* file or posted to the */api/v1/pipelines*
+API end point.
+
 ## Running
 The script parameters are:
 * --jar-files - A comma separated list of jar files. This should be the full path.
@@ -33,12 +38,23 @@ The script parameters are:
 
 Installation:
 * Download the tar file from the releases page
-* Expand the tar file (tar xzf application-utilities_2.11...)
+* Expand the tar file (tar xzf metalus-utils_2.11-spark_2.3...)
 * Change to the bin directory (cd application-utilities/bin)
-* Run the command:
+* Example commands:
 
+Write to a file:
 ```bash
-./metadata-extractor.sh --jar-files /tmp/steps.jar,/tmp/common-steps.jar --output-file steps.json
+./metadata-extractor.sh --jar-files /tmp/steps.jar,/tmp/common-steps.jar --output-path /tmp
+```
+
+Write to an api:
+```bash
+./metadata-extractor.sh --jar-files /tmp/steps.jar,/tmp/common-steps.jar --api-url htp://localhost:8000
+```
+
+Write to a file with an additional Extractor:
+```bash
+./metadata-extractor.sh --jar-files /tmp/steps.jar,/tmp/common-steps.jar --output-path /tmp --extractors com.acxiom.metalus.MyExampleExtractor
 ```
 
 ## Example using common steps

--- a/metalus-utils/readme.md
+++ b/metalus-utils/readme.md
@@ -1,8 +1,13 @@
 # Application Utilities
 Application utilities are provided as a way to make working with the project easier.
 
-## Step Metadata Extractor
-This utility will scan jar files that contain steps and produce a JSON representation. The tool takes a list of packages
+## Metadata Extractor
+The MetadataExtractor is a generic tool which will scan the provided jar files and extract specific metadata. The 
+StepMetadataExtractor executed by default and additional extractors can be executed as long as the classes are part of
+the provided jars and implement the **Extractor** trait. 
+
+### Step Metadata Extractor
+This extractor will scan jar files that contain steps and produce a JSON representation. The tool takes a list of packages
 and identifies objects with the annotation *StepObject*. Next the tool will look for any function annotated with the
 *StepFunction* annotation. Once a function has been identified, the parameters will be inspected to produce the **params**
 array. One additional annotation named *StepParameter* may be used to provide overrides:
@@ -19,11 +24,12 @@ parameters in each step.
 
 **Note:** When using annotations, all parameters must be supplied. Named parameters will not work.
 
-### Running
+## Running
 The script parameters are:
 * --jar-files - A comma separated list of jar files. This should be the full path.
-* --step-packages A comma separated list of packages to scan. *Example: com.acxiom.pipeline.steps*
-* --output-file - An optional file name to write the step metadata. The output will be written to the console otherwise.
+* --api-url The base URL to use when pushing data to an API. This parameter is optional.
+* --output-path - A path to write the JSON output. This parameter is optional.
+* --extractors - An optional comma separated list of extractor class names.
 
 Installation:
 * Download the tar file from the releases page
@@ -32,10 +38,10 @@ Installation:
 * Run the command:
 
 ```bash
-./step-metadata-extractor.sh --jar-files /tmp/steps.jar,/tmp/common-steps.jar --step-packages com.acxiom.pipeline.steps,com.mycompany.steps --output-file steps.json
+./metadata-extractor.sh --jar-files /tmp/steps.jar,/tmp/common-steps.jar --output-file steps.json
 ```
 
-### Example using common steps
+## Example using common steps
 
 ```json
 {
@@ -52,14 +58,29 @@ Installation:
       "params": [
         {
           "type": "text",
-          "name": "hiveStepsOptions",
+          "name": "table",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.HiveStepsOptions"
+          "parameterType": "String"
+        },
+        {
+          "type": "object",
+          "name": "options",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.DataFrameReaderOptions",
+          "parameterType": "com.acxiom.pipeline.steps.DataFrameReaderOptions"
         }
       ],
       "engineMeta": {
-        "spark": "HiveSteps.readDataFrame"
-      }
+        "spark": "HiveSteps.readDataFrame",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "e2b4c011-e71b-46f9-a8be-cf937abc2ec4",
@@ -71,46 +92,100 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
-          "name": "hiveStepsOptions",
+          "name": "table",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.HiveStepsOptions"
+          "parameterType": "String"
+        },
+        {
+          "type": "object",
+          "name": "options",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.DataFrameWriterOptions",
+          "parameterType": "com.acxiom.pipeline.steps.DataFrameWriterOptions"
         }
       ],
       "engineMeta": {
-        "spark": "HiveSteps.writeDataFrame"
-      }
+        "spark": "HiveSteps.writeDataFrame",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Unit"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "87db259d-606e-46eb-b723-82923349640f",
-      "displayName": "Load DataFrame from HDFS",
-      "description": "This step will create a dataFrame in a given format from HDFS",
+      "displayName": "Load DataFrame from HDFS path",
+      "description": "This step will read a dataFrame from the given HDFS path",
       "type": "Pipeline",
       "category": "InputOutput",
       "params": [
         {
           "type": "text",
           "name": "path",
-          "required": false
-        },
-        {
-          "type": "text",
-          "name": "format",
           "required": false,
-          "defaultValue": "parquet"
+          "parameterType": "String"
         },
         {
-          "type": "text",
-          "name": "properties",
-          "required": false
+          "type": "object",
+          "name": "options",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.DataFrameReaderOptions",
+          "parameterType": "com.acxiom.pipeline.steps.DataFrameReaderOptions"
         }
       ],
       "engineMeta": {
-        "spark": "HDFSSteps.readFromHDFS"
-      }
+        "spark": "HDFSSteps.readFromPath",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "8daea683-ecde-44ce-988e-41630d251cb8",
+      "displayName": "Load DataFrame from HDFS paths",
+      "description": "This step will read a dataFrame from the given HDFS paths",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "paths",
+          "required": false,
+          "parameterType": "scala.List[String]"
+        },
+        {
+          "type": "object",
+          "name": "options",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.DataFrameReaderOptions",
+          "parameterType": "com.acxiom.pipeline.steps.DataFrameReaderOptions"
+        }
+      ],
+      "engineMeta": {
+        "spark": "HDFSSteps.readFromPaths",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "0a296858-e8b7-43dd-9f55-88d00a7cd8fa",
@@ -122,33 +197,53 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
           "name": "path",
-          "required": false
-        },
-        {
-          "type": "text",
-          "name": "format",
           "required": false,
-          "defaultValue": "parquet"
+          "parameterType": "String"
         },
         {
-          "type": "text",
-          "name": "properties",
-          "required": false
-        },
-        {
-          "type": "text",
-          "name": "saveMode",
-          "required": false
+          "type": "object",
+          "name": "options",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.DataFrameWriterOptions",
+          "parameterType": "com.acxiom.pipeline.steps.DataFrameWriterOptions"
         }
       ],
       "engineMeta": {
-        "spark": "HDFSSteps.writeDataFrame"
-      }
+        "spark": "HDFSSteps.writeToPath",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Unit"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "e4dad367-a506-5afd-86c0-82c2cf5cd15c",
+      "displayName": "Create HDFS FileManager",
+      "description": "Simple function to generate the HDFSFileManager for the local HDFS file system",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [],
+      "engineMeta": {
+        "spark": "HDFSSteps.createFileManager",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Option[com.acxiom.pipeline.fs.HDFSFileManager]"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "a7e17c9d-6956-4be0-a602-5b5db4d1c08b",
@@ -161,12 +256,21 @@ Installation:
           "type": "script",
           "name": "script",
           "required": false,
-          "language": "scala"
+          "language": "scala",
+          "className": "String"
         }
       ],
       "engineMeta": {
-        "spark": "ScalaSteps.processScript"
-      }
+        "spark": "ScalaSteps.processScript",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "com.acxiom.pipeline.PipelineStepResponse"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "8bf8cef6-cf32-4d85-99f4-e4687a142f84",
@@ -179,25 +283,89 @@ Installation:
           "type": "script",
           "name": "script",
           "required": false,
-          "language": "scala"
+          "language": "scala",
+          "className": "String"
         },
         {
           "type": "text",
           "name": "value",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Any"
         },
         {
           "type": "text",
           "name": "type",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         }
       ],
       "engineMeta": {
-        "spark": "ScalaSteps.processScriptWithValue"
-      }
+        "spark": "ScalaSteps.processScriptWithValue",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "com.acxiom.pipeline.PipelineStepResponse"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "cdb332e3-9ea4-4c96-8b29-c1d74287656c",
+      "displayName": "Load table as DataFrame using JDBCOptions",
+      "description": "This step will load a table from the provided JDBCOptions",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "jdbcOptions",
+          "required": false,
+          "parameterType": "org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions"
+        }
+      ],
+      "engineMeta": {
+        "spark": "JDBCSteps.readWithJDBCOptions",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "72dbbfc8-bd1d-4ce4-ab35-28fa8385ea54",
+      "displayName": "Load table as DataFrame using StepOptions",
+      "description": "This step will load a table from the provided JDBCDataFrameReaderOptions",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "object",
+          "name": "jDBCStepsOptions",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.JDBCDataFrameReaderOptions",
+          "parameterType": "com.acxiom.pipeline.steps.JDBCDataFrameReaderOptions"
+        }
+      ],
+      "engineMeta": {
+        "spark": "JDBCSteps.readWithStepOptions",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "dcc57409-eb91-48c0-975b-ca109ba30195",
       "displayName": "Load table as DataFrame",
       "description": "This step will load a table from the provided jdbc information",
       "type": "Pipeline",
@@ -205,155 +373,161 @@ Installation:
       "params": [
         {
           "type": "text",
-          "name": "jdbcOptions",
-          "required": false
-        }
-      ],
-      "engineMeta": {
-        "spark": "JDBCSteps.readWithJDBCOptions"
-      }
-    },
-    {
-      "id": "72dbbfc8-bd1d-4ce4-ab35-28fa8385ea54",
-      "displayName": "Load JDBC table as DataFrame",
-      "description": "This step will load a table from the provided jdbc step options",
-      "type": "Pipeline",
-      "category": "InputOutput",
-      "params": [
-        {
-          "type": "text",
-          "name": "jDBCStepsOptions",
-          "required": false,
-          "className": "com.acxiom.pipeline.steps.JDBCStepsOptions"
-        }
-      ],
-      "engineMeta": {
-        "spark": "JDBCSteps.readWithStepOptions"
-      }
-    },
-    {
-      "id": "dcc57409-eb91-48c0-975b-ca109ba30195",
-      "displayName": "Load JDBC table as DataFrame with Properties",
-      "description": "This step will load a table from the provided jdbc information",
-      "type": "Pipeline",
-      "category": "InputOutput",
-      "params": [
-        {
-          "type": "text",
           "name": "url",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         },
         {
           "type": "text",
           "name": "table",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         },
         {
           "type": "text",
           "name": "predicates",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[scala.List[String]]"
         },
         {
           "type": "text",
           "name": "connectionProperties",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[Map[String,String]]"
         }
       ],
       "engineMeta": {
-        "spark": "JDBCSteps.readWithProperties"
-      }
+        "spark": "JDBCSteps.readWithProperties",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "c9fddf52-34b1-4216-a049-10c33ccd24ab",
-      "displayName": "Write DataFrame to JDBC table",
-      "description": "This step will write a DataFrame as a table using JDBC",
+      "displayName": "Write DataFrame to table using JDBCOptions",
+      "description": "This step will write a DataFrame as a table using JDBCOptions",
       "type": "Pipeline",
       "category": "InputOutput",
       "params": [
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
           "name": "jdbcOptions",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions"
         },
         {
           "type": "text",
           "name": "saveMode",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         }
       ],
       "engineMeta": {
-        "spark": "JDBCSteps.writeWithJDBCOptions"
-      }
+        "spark": "JDBCSteps.writeWithJDBCOptions",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Unit"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "77ffcd02-fbd0-4f79-9b35-ac9dc5fb7190",
-      "displayName": "Write DataFrame to JDBC table with Properties",
-      "description": "This step will write a DataFrame as a table using JDBC and provided properties",
+      "displayName": "Write DataFrame to table",
+      "description": "This step will write a DataFrame to a table using the provided properties",
       "type": "Pipeline",
       "category": "InputOutput",
       "params": [
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
           "name": "url",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         },
         {
           "type": "text",
           "name": "table",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         },
         {
           "type": "text",
           "name": "connectionProperties",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[Map[String,String]]"
         },
         {
           "type": "text",
           "name": "saveMode",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         }
       ],
       "engineMeta": {
-        "spark": "JDBCSteps.writeWithProperties"
-      }
+        "spark": "JDBCSteps.writeWithProperties",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Unit"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "3d6b77a1-52c2-49ba-99a0-7ec773dac696",
       "displayName": "Write DataFrame to JDBC table",
-      "description": "This step will write a DataFrame as a table using JDBC using JDBCStepOptions",
+      "description": "This step will write a DataFrame to a table using the provided JDBCDataFrameWriterOptions",
       "type": "Pipeline",
       "category": "InputOutput",
       "params": [
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
-          "type": "text",
+          "type": "object",
           "name": "jDBCStepsOptions",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.JDBCStepsOptions"
-        },
-        {
-          "type": "text",
-          "name": "saveMode",
-          "required": false
+          "className": "com.acxiom.pipeline.steps.JDBCDataFrameWriterOptions",
+          "parameterType": "com.acxiom.pipeline.steps.JDBCDataFrameWriterOptions"
         }
       ],
       "engineMeta": {
-        "spark": "JDBCSteps.writeWithStepOptions"
-      }
+        "spark": "JDBCSteps.writeWithStepOptions",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Unit"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "219c787a-f502-4efc-b15d-5beeff661fc0",
@@ -365,28 +539,40 @@ Installation:
         {
           "type": "text",
           "name": "inputDataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
           "name": "destinationDataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
-          "type": "text",
+          "type": "object",
           "name": "transforms",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.Transformations"
+          "className": "com.acxiom.pipeline.steps.Transformations",
+          "parameterType": "com.acxiom.pipeline.steps.Transformations"
         },
         {
-          "type": "text",
+          "type": "boolean",
           "name": "addNewColumns",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Boolean"
         }
       ],
       "engineMeta": {
-        "spark": "TransformationSteps.mapToDestinationDataFrame"
-      }
+        "spark": "TransformationSteps.mapToDestinationDataFrame",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "8f9c08ea-4882-4265-bac7-2da3e942758f",
@@ -398,29 +584,41 @@ Installation:
         {
           "type": "text",
           "name": "inputDataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
-          "type": "text",
+          "type": "object",
           "name": "destinationSchema",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.Schema"
+          "className": "com.acxiom.pipeline.steps.Schema",
+          "parameterType": "com.acxiom.pipeline.steps.Schema"
         },
         {
-          "type": "text",
+          "type": "object",
           "name": "transforms",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.Transformations"
+          "className": "com.acxiom.pipeline.steps.Transformations",
+          "parameterType": "com.acxiom.pipeline.steps.Transformations"
         },
         {
-          "type": "text",
+          "type": "boolean",
           "name": "addNewColumns",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Boolean"
         }
       ],
       "engineMeta": {
-        "spark": "TransformationSteps.mapDataFrameToSchema"
-      }
+        "spark": "TransformationSteps.mapDataFrameToSchema",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "3ee74590-9131-43e1-8ee8-ad320482a592",
@@ -432,28 +630,40 @@ Installation:
         {
           "type": "text",
           "name": "inputDataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
           "name": "destinationDataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
-          "type": "text",
+          "type": "object",
           "name": "transforms",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.Transformations"
+          "className": "com.acxiom.pipeline.steps.Transformations",
+          "parameterType": "com.acxiom.pipeline.steps.Transformations"
         },
         {
-          "type": "text",
+          "type": "boolean",
           "name": "addNewColumns",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Boolean"
         }
       ],
       "engineMeta": {
-        "spark": "TransformationSteps.mergeDataFrames"
-      }
+        "spark": "TransformationSteps.mergeDataFrames",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "ac3dafe4-e6ee-45c9-8fc6-fa7f918cf4f2",
@@ -465,18 +675,28 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
-          "type": "text",
+          "type": "object",
           "name": "transforms",
           "required": false,
-          "className": "com.acxiom.pipeline.steps.Transformations"
+          "className": "com.acxiom.pipeline.steps.Transformations",
+          "parameterType": "com.acxiom.pipeline.steps.Transformations"
         }
       ],
       "engineMeta": {
-        "spark": "TransformationSteps.applyTransforms"
-      }
+        "spark": "TransformationSteps.applyTransforms",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "fa0fcabb-d000-4a5e-9144-692bca618ddb",
@@ -488,17 +708,27 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
           "name": "expression",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         }
       ],
       "engineMeta": {
-        "spark": "TransformationSteps.applyFilter"
-      }
+        "spark": "TransformationSteps.applyFilter",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "a981080d-714c-4d36-8b09-d95842ec5655",
@@ -510,12 +740,21 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         }
       ],
       "engineMeta": {
-        "spark": "TransformationSteps.standardizeColumnNames"
-      }
+        "spark": "TransformationSteps.standardizeColumnNames",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "541c4f7d-3524-4d53-bbd9-9f2cfd9d1bd1",
@@ -527,17 +766,27 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "text",
           "name": "viewName",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[String]"
         }
       ],
       "engineMeta": {
-        "spark": "QuerySteps.dataFrameToTempView"
-      }
+        "spark": "QuerySteps.dataFrameToTempView",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "String"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "71b71ef3-eaa7-4a1f-b3f3-603a1a54846d",
@@ -550,22 +799,33 @@ Installation:
           "type": "script",
           "name": "query",
           "required": false,
-          "language": "sql"
+          "language": "sql",
+          "className": "String"
         },
         {
           "type": "text",
           "name": "variableMap",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[Map[String,String]]"
         },
         {
           "type": "text",
           "name": "viewName",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[String]"
         }
       ],
       "engineMeta": {
-        "spark": "QuerySteps.queryToTempView"
-      }
+        "spark": "QuerySteps.queryToTempView",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "String"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "61378ed6-8a4f-4e6d-9c92-6863c9503a54",
@@ -578,17 +838,27 @@ Installation:
           "type": "script",
           "name": "query",
           "required": false,
-          "language": "sql"
+          "language": "sql",
+          "className": "String"
         },
         {
           "type": "text",
           "name": "variableMap",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[Map[String,String]]"
         }
       ],
       "engineMeta": {
-        "spark": "QuerySteps.queryToDataFrame"
-      }
+        "spark": "QuerySteps.queryToDataFrame",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "57b0e491-e09b-4428-aab2-cebe1f217eda",
@@ -600,12 +870,21 @@ Installation:
         {
           "type": "text",
           "name": "viewName",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         }
       ],
       "engineMeta": {
-        "spark": "QuerySteps.tempViewToDataFrame"
-      }
+        "spark": "QuerySteps.tempViewToDataFrame",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "648f27aa-6e3b-44ed-a093-bc284783731b",
@@ -617,33 +896,46 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "script",
           "name": "query",
           "required": false,
-          "language": "sql"
+          "language": "sql",
+          "className": "String"
         },
         {
           "type": "text",
           "name": "variableMap",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[Map[String,String]]"
         },
         {
           "type": "text",
           "name": "inputViewName",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         },
         {
           "type": "text",
           "name": "outputViewName",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[String]"
         }
       ],
       "engineMeta": {
-        "spark": "QuerySteps.dataFrameQueryToTempView"
-      }
+        "spark": "QuerySteps.dataFrameQueryToTempView",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "String"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "dfb8a387-6245-4b1c-ae6c-94067eb83962",
@@ -655,28 +947,40 @@ Installation:
         {
           "type": "text",
           "name": "dataFrame",
-          "required": false
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
         },
         {
           "type": "script",
           "name": "query",
           "required": false,
-          "language": "sql"
+          "language": "sql",
+          "className": "String"
         },
         {
           "type": "text",
           "name": "variableMap",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Option[Map[String,String]]"
         },
         {
           "type": "text",
           "name": "inputViewName",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         }
       ],
       "engineMeta": {
-        "spark": "QuerySteps.dataFrameQueryToDataFrame"
-      }
+        "spark": "QuerySteps.dataFrameQueryToDataFrame",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "c88de095-14e0-4c67-8537-0325127e2bd2",
@@ -688,12 +992,319 @@ Installation:
         {
           "type": "text",
           "name": "viewName",
-          "required": false
+          "required": false,
+          "parameterType": "String"
         }
       ],
       "engineMeta": {
-        "spark": "QuerySteps.cacheTempView"
-      }
+        "spark": "QuerySteps.cacheTempView",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrame"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "0342654c-2722-56fe-ba22-e342169545af",
+      "displayName": "Copy source contents to destination",
+      "description": "Copy the contents of the source path to the destination path. This function will call connect on both FileManagers.",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "srcFS",
+          "required": false,
+          "parameterType": "com.acxiom.pipeline.fs.FileManager"
+        },
+        {
+          "type": "text",
+          "name": "srcPath",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "destFS",
+          "required": false,
+          "parameterType": "com.acxiom.pipeline.fs.FileManager"
+        },
+        {
+          "type": "text",
+          "name": "destPath",
+          "required": false,
+          "parameterType": "String"
+        }
+      ],
+      "engineMeta": {
+        "spark": "FileManagerSteps.copy",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "com.acxiom.pipeline.steps.CopyResults"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "c40169a3-1e77-51ab-9e0a-3f24fb98beef",
+      "displayName": "Copy source contents to destination with buffering",
+      "description": "Copy the contents of the source path to the destination path using buffer sizes. This function will call connect on both FileManagers.",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "srcFS",
+          "required": false,
+          "parameterType": "com.acxiom.pipeline.fs.FileManager"
+        },
+        {
+          "type": "text",
+          "name": "srcPath",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "destFS",
+          "required": false,
+          "parameterType": "com.acxiom.pipeline.fs.FileManager"
+        },
+        {
+          "type": "text",
+          "name": "destPath",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "inputBufferSize",
+          "required": false,
+          "parameterType": "scala.Int"
+        },
+        {
+          "type": "text",
+          "name": "outputBufferSize",
+          "required": false,
+          "parameterType": "scala.Int"
+        }
+      ],
+      "engineMeta": {
+        "spark": "FileManagerSteps.copy",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "com.acxiom.pipeline.steps.CopyResults"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "f5a24db0-e91b-5c88-8e67-ab5cff09c883",
+      "displayName": "Buffered file copy",
+      "description": "Copy the contents of the source path to the destination path using full buffer sizes. This function will call connect on both FileManagers.",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "srcFS",
+          "required": false,
+          "parameterType": "com.acxiom.pipeline.fs.FileManager"
+        },
+        {
+          "type": "text",
+          "name": "srcPath",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "destFS",
+          "required": false,
+          "parameterType": "com.acxiom.pipeline.fs.FileManager"
+        },
+        {
+          "type": "text",
+          "name": "destPath",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "inputBufferSize",
+          "required": false,
+          "parameterType": "scala.Int"
+        },
+        {
+          "type": "text",
+          "name": "outputBufferSize",
+          "required": false,
+          "parameterType": "scala.Int"
+        },
+        {
+          "type": "text",
+          "name": "copyBufferSize",
+          "required": false,
+          "parameterType": "scala.Int"
+        }
+      ],
+      "engineMeta": {
+        "spark": "FileManagerSteps.copy",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "com.acxiom.pipeline.steps.CopyResults"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "3d1e8519-690c-55f0-bd05-1e7b97fb6633",
+      "displayName": "Disconnect a FileManager",
+      "description": "Disconnects a FileManager from the underlying file system",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "fileManager",
+          "required": false,
+          "parameterType": "com.acxiom.pipeline.fs.FileManager"
+        }
+      ],
+      "engineMeta": {
+        "spark": "FileManagerSteps.disconnectFileManager",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Unit"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "9d467cb0-8b3d-40a0-9ccd-9cf8c5b6cb38",
+      "displayName": "Create SFTP FileManager",
+      "description": "Simple function to generate the SFTPFileManager for the remote SFTP file system",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "hostName",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "username",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "password",
+          "required": false,
+          "parameterType": "String"
+        },
+        {
+          "type": "text",
+          "name": "port",
+          "required": false,
+          "parameterType": "scala.Int"
+        },
+        {
+          "type": "text",
+          "name": "strictHostChecking",
+          "required": false,
+          "parameterType": "scala.Option[scala.Boolean]"
+        }
+      ],
+      "engineMeta": {
+        "spark": "SFTPSteps.createFileManager",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "scala.Option[com.acxiom.pipeline.fs.SFTPFileManager]"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "22fcc0e7-0190-461c-a999-9116b77d5919",
+      "displayName": "Build a DataFrameReader Object",
+      "description": "This step will build a DataFrameReader object that can be used to read a file into a dataframe",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "object",
+          "name": "dataFrameReaderOptions",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.DataFrameReaderOptions",
+          "parameterType": "com.acxiom.pipeline.steps.DataFrameReaderOptions"
+        }
+      ],
+      "engineMeta": {
+        "spark": "DataFrameSteps.getDataFrameReader",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrameReader"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
+    },
+    {
+      "id": "e023fc14-6cb7-44cb-afce-7de01d5cdf00",
+      "displayName": "Build a DataFrameWriter Object",
+      "description": "This step will build a DataFrameWriter object that can be used to write a file into a dataframe",
+      "type": "Pipeline",
+      "category": "InputOutput",
+      "params": [
+        {
+          "type": "text",
+          "name": "dataFrame",
+          "required": false,
+          "parameterType": "org.apache.spark.sql.DataFrame"
+        },
+        {
+          "type": "object",
+          "name": "options",
+          "required": false,
+          "className": "com.acxiom.pipeline.steps.DataFrameWriterOptions",
+          "parameterType": "com.acxiom.pipeline.steps.DataFrameWriterOptions"
+        }
+      ],
+      "engineMeta": {
+        "spark": "DataFrameSteps.getDataFrameWriter",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "org.apache.spark.sql.DataFrameWriter[org.apache.spark.sql.Row]"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "5e0358a0-d567-5508-af61-c35a69286e4e",
@@ -706,12 +1317,21 @@ Installation:
           "type": "script",
           "name": "script",
           "required": false,
-          "language": "javascript"
+          "language": "javascript",
+          "className": "String"
         }
       ],
       "engineMeta": {
-        "spark": "JavascriptSteps.processScript"
-      }
+        "spark": "JavascriptSteps.processScript",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "com.acxiom.pipeline.PipelineStepResponse"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     },
     {
       "id": "570c9a80-8bd1-5f0c-9ae0-605921fe51e2",
@@ -724,35 +1344,53 @@ Installation:
           "type": "script",
           "name": "script",
           "required": false,
-          "language": "javascript"
+          "language": "javascript",
+          "className": "String"
         },
         {
           "type": "text",
           "name": "value",
-          "required": false
+          "required": false,
+          "parameterType": "scala.Any"
         }
       ],
       "engineMeta": {
-        "spark": "JavascriptSteps.processScriptWithValue"
-      }
+        "spark": "JavascriptSteps.processScriptWithValue",
+        "pkg": "com.acxiom.pipeline.steps",
+        "results": {
+          "primaryType": "com.acxiom.pipeline.PipelineStepResponse"
+        }
+      },
+      "tags": [
+        "metalus-common_2.11-spark_2.3-1.5.0-SNAPSHOT.jar",
+        "metalus-common_2.11-spark_2.4-1.5.0-SNAPSHOT.jar"
+      ]
     }
   ],
   "pkgObjs": [
     {
-      "id": "com.acxiom.pipeline.steps.HiveStepsOptions",
-      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"format\":{\"type\":\"string\"},\"partitionBy\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"sortBy\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"bucketingOptions\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"numBuckets\":{\"type\":\"integer\"},\"columns\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"required\":[\"numBuckets\",\"columns\"]},\"options\":{\"type\":\"object\",\"patternProperties\":{\"^.*$\":{\"type\":\"string\"}}},\"saveMode\":{\"type\":\"string\"},\"table\":{\"type\":\"string\"}},\"required\":[\"table\"]}"
+      "id": "com.acxiom.pipeline.steps.JDBCDataFrameReaderOptions",
+      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"JDBC Data Frame Reader Options\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"url\":{\"type\":\"string\"},\"table\":{\"type\":\"string\"},\"predicates\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"readerOptions\":{\"$ref\":\"#/definitions/DataFrameReaderOptions\"}},\"definitions\":{\"DataFrameReaderOptions\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"format\":{\"type\":\"string\"},\"options\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"schema\":{\"$ref\":\"#/definitions/Schema\"}}},\"Schema\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"attributes\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Attribute\"}}}},\"Attribute\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"name\":{\"type\":\"string\"},\"dataType\":{\"$ref\":\"#/definitions/AttributeType\"}}},\"AttributeType\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"baseType\":{\"type\":\"string\"},\"valueType\":{\"$ref\":\"#/definitions/AttributeType\"},\"nameType\":{\"$ref\":\"#/definitions/AttributeType\"},\"schema\":{\"$ref\":\"#/definitions/Schema\"}}}}}"
     },
     {
-      "id": "com.acxiom.pipeline.steps.JDBCStepsOptions",
-      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"url\":{\"type\":\"string\"},\"table\":{\"type\":\"string\"},\"predicates\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"connectionProperties\":{\"type\":\"object\",\"patternProperties\":{\"^.*$\":{\"type\":\"string\"}}}},\"required\":[\"url\",\"table\"]}"
+      "id": "com.acxiom.pipeline.steps.DataFrameWriterOptions",
+      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"Data Frame Writer Options\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"format\":{\"type\":\"string\"},\"saveMode\":{\"type\":\"string\"},\"options\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"bucketingOptions\":{\"$ref\":\"#/definitions/BucketingOptions\"},\"partitionBy\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"sortBy\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"definitions\":{\"BucketingOptions\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"numBuckets\":{\"type\":\"integer\"},\"columns\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"required\":[\"numBuckets\"]}}}"
+    },
+    {
+      "id": "com.acxiom.pipeline.steps.DataFrameReaderOptions",
+      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"Data Frame Reader Options\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"format\":{\"type\":\"string\"},\"options\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"schema\":{\"$ref\":\"#/definitions/Schema\"}},\"definitions\":{\"Schema\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"attributes\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Attribute\"}}}},\"Attribute\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"name\":{\"type\":\"string\"},\"dataType\":{\"$ref\":\"#/definitions/AttributeType\"}}},\"AttributeType\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"baseType\":{\"type\":\"string\"},\"valueType\":{\"$ref\":\"#/definitions/AttributeType\"},\"nameType\":{\"$ref\":\"#/definitions/AttributeType\"},\"schema\":{\"$ref\":\"#/definitions/Schema\"}}}}}"
     },
     {
       "id": "com.acxiom.pipeline.steps.Transformations",
-      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"columnDetails\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"outputField\":{\"type\":\"string\"},\"inputAliases\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"expression\":{\"type\":\"string\"}},\"required\":[\"outputField\"]}},\"filter\":{\"type\":\"string\"},\"standardizeColumnNames\":{\"type\":\"boolean\"}},\"required\":[\"columnDetails\"]}"
+      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"Transformations\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"columnDetails\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/ColumnDetails\"}},\"filter\":{\"type\":\"string\"},\"standardizeColumnNames\":{}},\"definitions\":{\"ColumnDetails\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"outputField\":{\"type\":\"string\"},\"inputAliases\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"expression\":{\"type\":\"string\"}}}}}"
     },
     {
       "id": "com.acxiom.pipeline.steps.Schema",
-      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"attributes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"name\":{\"type\":\"string\"},\"dataType\":{\"type\":\"string\"}},\"required\":[\"name\",\"dataType\"]}}},\"required\":[\"attributes\"]}"
+      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"Schema\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"attributes\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Attribute\"}}},\"definitions\":{\"Attribute\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"name\":{\"type\":\"string\"},\"dataType\":{\"$ref\":\"#/definitions/AttributeType\"}}},\"AttributeType\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"baseType\":{\"type\":\"string\"},\"valueType\":{\"$ref\":\"#/definitions/AttributeType\"},\"nameType\":{\"$ref\":\"#/definitions/AttributeType\"},\"schema\":{\"$ref\":\"#/definitions/Schema\"}}},\"Schema\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"attributes\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Attribute\"}}}}}}"
+    },
+    {
+      "id": "com.acxiom.pipeline.steps.JDBCDataFrameWriterOptions",
+      "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"JDBC Data Frame Writer Options\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"url\":{\"type\":\"string\"},\"table\":{\"type\":\"string\"},\"writerOptions\":{\"$ref\":\"#/definitions/DataFrameWriterOptions\"}},\"definitions\":{\"DataFrameWriterOptions\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"format\":{\"type\":\"string\"},\"saveMode\":{\"type\":\"string\"},\"options\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"bucketingOptions\":{\"$ref\":\"#/definitions/BucketingOptions\"},\"partitionBy\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"sortBy\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"BucketingOptions\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"numBuckets\":{\"type\":\"integer\"},\"columns\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"required\":[\"numBuckets\"]}}}"
     }
   ]
 }

--- a/metalus-utils/src/main/scala/com/acxiom/metalus/MetadataExtractor.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/metalus/MetadataExtractor.scala
@@ -21,8 +21,16 @@ object MetadataExtractor {
     } else {
       Output(None, None)
     }
+    val extractors = DEFAULT_EXTRACTORS.filter(extractor => {
+      (extractor == "com.acxiom.metalus.pipelines.PipelineMetadataExtractor" &&
+        (!parameters.contains("excludePipelines") ||
+        !parameters("excludePipelines").asInstanceOf[Boolean])) ||
+        (extractor == "com.acxiom.metalus.steps.StepMetadataExtractor" &&
+          (!parameters.contains("excludeSteps") ||
+          !parameters("excludeSteps").asInstanceOf[Boolean]))
+    })
     // Iterate the registered extractor
-    (parameters.getOrElse("extractors", "").asInstanceOf[String].split(",").toList ::: DEFAULT_EXTRACTORS)
+    (parameters.getOrElse("extractors", "").asInstanceOf[String].split(",").toList ::: extractors)
       .filter(_.nonEmpty)
       .foreach(extractor => {
         val extract = ReflectionUtils.loadClass(extractor).asInstanceOf[Extractor]

--- a/metalus-utils/src/main/scala/com/acxiom/metalus/MetadataExtractor.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/metalus/MetadataExtractor.scala
@@ -1,4 +1,4 @@
-package com.acxiom.pipeline
+package com.acxiom.metalus
 
 import java.io.{File, FileWriter}
 import java.util.jar.JarFile
@@ -7,7 +7,9 @@ import com.acxiom.pipeline.api.HttpRestClient
 import com.acxiom.pipeline.utils.{DriverUtils, ReflectionUtils}
 
 object MetadataExtractor {
-  private val DEFAULT_EXTRACTORS = List[String]("com.acxiom.pipeline.steps.StepMetadataExtractor")
+  private val DEFAULT_EXTRACTORS = List[String](
+    "com.acxiom.metalus.steps.StepMetadataExtractor",
+    "com.acxiom.metalus.pipelines.PipelineMetadataExtractor")
 
   def main(args: Array[String]): Unit = {
     val parameters = DriverUtils.extractParameters(args, Some(List("jar-files")))
@@ -24,7 +26,7 @@ object MetadataExtractor {
       .filter(_.nonEmpty)
       .foreach(extractor => {
         val extract = ReflectionUtils.loadClass(extractor).asInstanceOf[Extractor]
-        val metadata = extract.extractMetadata(jarFiles, output)
+        val metadata = extract.extractMetadata(jarFiles)
         extract.writeOutputFile(metadata, output)
       })
   }
@@ -39,9 +41,8 @@ trait Extractor {
   /**
     * Called by the MetadataExtractor to extract metadata from the provided jar files and write the data using the provided output.
     * @param jarFiles A list of JarFile objects that should be scanned.
-    * @param output Information about how to output the metadata.
     */
-  def extractMetadata(jarFiles: List[JarFile], output: Output): Metadata
+  def extractMetadata(jarFiles: List[JarFile]): Metadata
 
   /**
     * This function should return a simple type that indicates what type of metadata this extractor produces.

--- a/metalus-utils/src/main/scala/com/acxiom/metalus/pipelines/PipelineMetadataExtractor.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/metalus/pipelines/PipelineMetadataExtractor.scala
@@ -24,8 +24,7 @@ class PipelineMetadataExtractor extends Extractor {
       val updatedPipelines = file.entries().toList
         .filter(f => f.getName.startsWith("metadata/pipelines") && f.getName.endsWith(".json"))
         .foldLeft(pipelines)((pipelineList, json) => {
-          val pipelineJson = Source.fromInputStream(file.getInputStream(file.getEntry(json.getName))).mkString
-          val pipeline = DriverUtils.parsePipelineJson(if (pipelineJson.trim()(0) != '[') { s"[$pipelineJson]" } else { pipelineJson })
+          val pipeline = DriverUtils.parsePipelineJson(Source.fromInputStream(file.getInputStream(file.getEntry(json.getName))).mkString)
           if (pipeline.isDefined) {
             pipelineList.foldLeft(pipeline.get)((pipelines, pipeline) => {
               if (pipelines.exists(p => p.id == pipeline.id)) {

--- a/metalus-utils/src/main/scala/com/acxiom/metalus/pipelines/PipelineMetadataExtractor.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/metalus/pipelines/PipelineMetadataExtractor.scala
@@ -1,0 +1,55 @@
+package com.acxiom.metalus.pipelines
+
+import java.util.jar.JarFile
+
+import com.acxiom.metalus.{Extractor, Metadata}
+import com.acxiom.pipeline.Pipeline
+import com.acxiom.pipeline.utils.DriverUtils
+import org.json4s.native.Serialization
+import org.json4s.{DefaultFormats, Formats}
+
+import scala.collection.JavaConversions._
+import scala.io.Source
+
+class PipelineMetadataExtractor extends Extractor {
+  implicit val formats: Formats = DefaultFormats
+
+  /**
+    * Called by the MetadataExtractor to extract metadata from the provided jar files and write the data using the provided output.
+    *
+    * @param jarFiles A list of JarFile objects that should be scanned.
+    */
+  override def extractMetadata(jarFiles: List[JarFile]): Metadata = {
+    val pipelineMetadata = jarFiles.foldLeft(List[Pipeline]())((pipelines, file) => {
+      val updatedPipelines = file.entries().toList
+        .filter(f => f.getName.startsWith("metadata/pipelines") && f.getName.endsWith(".json"))
+        .foldLeft(pipelines)((pipelineList, json) => {
+          val pipelineJson = Source.fromInputStream(file.getInputStream(file.getEntry(json.getName))).mkString
+          val pipeline = DriverUtils.parsePipelineJson(if (pipelineJson.trim()(0) != '[') { s"[$pipelineJson]" } else { pipelineJson })
+          if (pipeline.isDefined) {
+            pipelineList.foldLeft(pipeline.get)((pipelines, pipeline) => {
+              if (pipelines.exists(p => p.id == pipeline.id)) {
+                pipelines
+              } else {
+                pipelines :+ pipeline
+              }
+            })
+            pipelineList ::: pipeline.get
+          } else {
+            pipelineList
+          }
+        })
+      pipelines ::: updatedPipelines
+    })
+    PipelineMetadata(Serialization.write(pipelineMetadata), pipelineMetadata)
+  }
+
+  /**
+    * This function should return a simple type that indicates what type of metadata this extractor produces.
+    *
+    * @return A simple string name.
+    */
+  override def getMetaDataType: String = "pipelines"
+}
+
+case class PipelineMetadata(value: String, pipelines: List[Pipeline]) extends Metadata

--- a/metalus-utils/src/main/scala/com/acxiom/metalus/steps/PipelineStepsDefinition.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/metalus/steps/PipelineStepsDefinition.scala
@@ -1,4 +1,4 @@
-package com.acxiom.pipeline.steps
+package com.acxiom.metalus.steps
 
 import com.acxiom.pipeline.EngineMeta
 

--- a/metalus-utils/src/main/scala/com/acxiom/pipeline/MetadataExtractor.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/pipeline/MetadataExtractor.scala
@@ -1,0 +1,80 @@
+package com.acxiom.pipeline
+
+import java.io.{File, FileWriter}
+import java.util.jar.JarFile
+
+import com.acxiom.pipeline.api.HttpRestClient
+import com.acxiom.pipeline.utils.{DriverUtils, ReflectionUtils}
+
+object MetadataExtractor {
+  private val DEFAULT_EXTRACTORS = List[String]("com.acxiom.pipeline.steps.StepMetadataExtractor")
+
+  def main(args: Array[String]): Unit = {
+    val parameters = DriverUtils.extractParameters(args, Some(List("jar-files")))
+    val jarFiles = parameters("jar-files").asInstanceOf[String].split(",").toList.map(file => new JarFile(new File(file)))
+    val output = if(parameters.contains("output-path")) {
+      Output(None, Some(new File(parameters("output-path").asInstanceOf[String])))
+    } else if(parameters.contains("api-url")) {
+      Output(Some(DriverUtils.getHttpRestClient(parameters("api-url").asInstanceOf[String], parameters)), None)
+    } else {
+      Output(None, None)
+    }
+    // Iterate the registered extractor
+    (parameters.getOrElse("extractors", "").asInstanceOf[String].split(",").toList ::: DEFAULT_EXTRACTORS)
+      .filter(_.nonEmpty)
+      .foreach(extractor => {
+        val extract = ReflectionUtils.loadClass(extractor).asInstanceOf[Extractor]
+        val metadata = extract.extractMetadata(jarFiles, output)
+        extract.writeOutputFile(metadata, output)
+      })
+  }
+}
+
+trait Extractor {
+  val FOUR: Int = 4
+  val SEVEN: Int = 7
+
+  val apiPath: String = ""
+
+  /**
+    * Called by the MetadataExtractor to extract metadata from the provided jar files and write the data using the provided output.
+    * @param jarFiles A list of JarFile objects that should be scanned.
+    * @param output Information about how to output the metadata.
+    */
+  def extractMetadata(jarFiles: List[JarFile], output: Output): Metadata
+
+  /**
+    * This function should return a simple type that indicates what type of metadata this extractor produces.
+    * @return A simple string name.
+    */
+  def getMetaDataType: String
+
+  /**
+    * Provides a basic function for handling output.
+    * @param metadata The metadata string to be written.
+    * @param output Information about how to output the metadata.
+    */
+  def writeOutputFile(metadata: Metadata, output: Output): Unit = {
+    if (output.path.nonEmpty) {
+      val file = new File(output.path.get, s"${this.getMetaDataType}.json")
+      val writer = new FileWriter(file)
+      writer.write(metadata.value)
+      writer.flush()
+      writer.close()
+    }
+    if (output.api.isDefined) {
+      output.api.get.postJsonContent(s"/api/v1/${this.getMetaDataType}", metadata.value)
+    }
+    if (output.api.isEmpty && output.path.isEmpty) {
+      print(metadata)
+    }
+  }
+}
+
+trait Metadata {
+  def value: String
+}
+
+case class JsonMetaData(value: String) extends Metadata
+
+case class Output(api: Option[HttpRestClient], path: Option[File])

--- a/metalus-utils/src/main/scala/com/acxiom/pipeline/steps/PipelineStepsDefinition.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/pipeline/steps/PipelineStepsDefinition.scala
@@ -1,4 +1,4 @@
-package com.acxiom.pipeline.annotations
+package com.acxiom.pipeline.steps
 
 import com.acxiom.pipeline.EngineMeta
 

--- a/metalus-utils/src/main/scala/com/acxiom/pipeline/steps/StepMetadataExtractor.scala
+++ b/metalus-utils/src/main/scala/com/acxiom/pipeline/steps/StepMetadataExtractor.scala
@@ -1,70 +1,81 @@
-package com.acxiom.pipeline.annotations
+package com.acxiom.pipeline.steps
 
-import java.io.{File, FileWriter}
 import java.util.jar.JarFile
 
-import com.acxiom.pipeline.EngineMeta
-import com.acxiom.pipeline.utils.DriverUtils
+import scala.collection.JavaConversions._
+import com.acxiom.pipeline.annotations.{BranchResults, PrivateObject, StepFunction, StepObject, StepParameter}
+import com.acxiom.pipeline.{EngineMeta, Extractor, Metadata, Output, StepResults}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.json4s.native.Serialization
 import org.json4s.{DefaultFormats, Formats}
 
-import scala.collection.JavaConversions._
-import scala.reflect.runtime.{universe => ru}
 import scala.util.{Failure, Success, Try}
+import scala.reflect.runtime.{universe => ru}
 
-
-/**
-  * This class will scan the provided stepPackages for annotated step objects and step functions. The output will be
-  * JSON.
-  *
-  * --step-packages - required package(s) to scan. Can be a comma separated string to scan multiple packages.
-  * --jar-files - comma separated list of jar files to scan
-  * --output-file - optional file path to write the JSON. Otherwise, output will be to the console.
-  */
-object StepMetaDataExtractor {
+class StepMetadataExtractor extends Extractor {
   implicit val formats: Formats = DefaultFormats
 
-  private val FOUR = 4
-  private val SEVEN = 7
+  override def getMetaDataType: String = "steps"
 
-  def main(args: Array[String]): Unit = {
-    val parameters = DriverUtils.extractParameters(args, Some(List("step-packages", "jar-files")))
-    val stepPackages = parameters("step-packages").asInstanceOf[String].split(",").toList
-    val jarFiles = parameters("jar-files").asInstanceOf[String].split(",").toList
-    val stepMappingsAndClasses = jarFiles.foldLeft((Map[String, List[StepDefinition]](), Set[String]()))((packageDefinitions, file) => {
-      stepPackages.foldLeft(packageDefinitions)((definitions, packageName) => {
-        val pack = packageName.replaceAll("\\.", "/")
-        val classFiles = new JarFile(new File(file)).entries().toList.filter(e => {
-          e.getName.substring(0, e.getName.lastIndexOf("/")) == pack && e.getName.indexOf(".") != -1
-        })
-        val jarStepsAndClasses = classFiles.foldLeft(
-          (packageDefinitions._1.getOrElse(packageName, List[StepDefinition]()), definitions._2))((stepDefinitions, cf) => {
-          val stepPath = s"${cf.getName.substring(0, cf.getName.indexOf(".")).replaceAll("/", "\\.")}"
-          if (!stepPath.contains("$")) {
-            val stepsAndClasses = findStepDefinitions(stepPath, packageName, file.substring(file.lastIndexOf('/') + 1))
-            val steps = if (stepsAndClasses.nonEmpty) Some(stepsAndClasses.get._1) else None
-            val classes = if (stepsAndClasses.nonEmpty) Some(stepsAndClasses.get._2) else None
-            val updatedCaseClasses = if (classes.isDefined) stepDefinitions._2 ++ classes.get else stepDefinitions._2
-            val updatedSteps = if (steps.isDefined) reconcileSteps(stepDefinitions._1, steps.get) else stepDefinitions._1
-            (updatedSteps, updatedCaseClasses)
-          } else { stepDefinitions }
-        })
-        val jarSteps = jarStepsAndClasses._1
-        val jarCaseClasses = jarStepsAndClasses._2
-        val lastDefinitions = if (definitions._1.contains(packageName)) {
-          definitions._1 + (packageName -> reconcileSteps(definitions._1(packageName), jarSteps))
+  override def extractMetadata(jarFiles: List[JarFile], output: Output): Metadata = {
+    val stepMappings = jarFiles.foldLeft((List[StepDefinition](), Set[String]()))((stepDefinitions, file) => {
+      file.entries().toList.filter(f => f.getName.endsWith(".class")).foldLeft(stepDefinitions)((definitions, cf) => {
+        val stepPath = s"${cf.getName.substring(0, cf.getName.indexOf(".")).replaceAll("/", "\\.")}"
+        if (!stepPath.contains("$")) {
+          val stepsAndClasses = findStepDefinitions(stepPath, file.getName.substring(file.getName.lastIndexOf('/') + 1))
+          val steps = if (stepsAndClasses.nonEmpty) Some(stepsAndClasses.get._1) else None
+          val classes = if (stepsAndClasses.nonEmpty) Some(stepsAndClasses.get._2) else None
+          val updatedCaseClasses = if (classes.isDefined) definitions._2 ++ classes.get else definitions._2
+          val updatedSteps = if (steps.isDefined) reconcileSteps(definitions._1, steps.get) else definitions._1
+          (updatedSteps, updatedCaseClasses)
         } else {
-          definitions._1 + (packageName -> jarSteps)
+          definitions
         }
-
-        (lastDefinitions, jarCaseClasses)
       })
     })
+    val definition = PipelineStepsDefinition(
+      stepMappings._1.map(_.engineMeta.pkg.getOrElse("")).distinct,
+      stepMappings._1,
+      buildPackageObjects(stepMappings._2)
+    )
+    StepMetadata(Serialization.write(definition), definition.pkgs, definition.steps, definition.pkgObjs)
+  }
 
-    val outputFile = if(parameters.contains("output-file")) Some(parameters("output-file").asInstanceOf[String]) else None
-    val packageObjects = buildPackageObjects(stepMappingsAndClasses._2)
-    writeStepMappings(stepMappingsAndClasses._1, packageObjects, outputFile)
+  /**
+    * Provides a basic function for handling output.
+    *
+    * @param metadata The metadata string to be written.
+    * @param output   Information about how to output the metadata.
+    */
+  override def writeOutputFile(metadata: Metadata, output: Output): Unit = {
+    if (output.api.isDefined) {
+      val http = output.api.get
+      val definition = metadata.asInstanceOf[StepMetadata]
+      if (http.exists("/api/v1/package-objects")) {
+        http.postJsonContent("/api/v1/package-objects", Serialization.write(definition.pkgObjs))
+      }
+      http.postJsonContent("/api/v1/steps", Serialization.write(definition.steps))
+    } else {
+      super.writeOutputFile(metadata, output)
+    }
+  }
+
+  private def buildPackageObjects(caseClasses: Set[String]): List[PackageObject] = {
+    import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator
+    import com.fasterxml.jackson.databind.ObjectMapper
+    import com.fasterxml.jackson.databind.JsonNode
+
+    caseClasses.map(x => {
+      val xClass = Class.forName(x)
+      val objectMapper = new ObjectMapper
+      objectMapper.registerModule(new DefaultScalaModule)
+      import com.kjetland.jackson.jsonSchema.JsonSchemaConfig
+      val config = JsonSchemaConfig.vanillaJsonSchemaDraft4
+      val jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper, debug = true, config)
+      val jsonSchema: JsonNode = jsonSchemaGenerator.generateJsonSchema(xClass)
+      val schema = objectMapper.writeValueAsString(jsonSchema).replaceFirst("draft-04", "draft-07")
+      PackageObject(x, schema)
+    }).toList
   }
 
   private def reconcileSteps(existingSteps: List[StepDefinition], newSteps: List[StepDefinition]): List[StepDefinition] = {
@@ -85,48 +96,6 @@ object StepMetaDataExtractor {
     })
   }
 
-  private def writeStepMappings(stepMappings: Map[String, List[StepDefinition]], packageObjects: List[PackageObject],
-                                outputFile: Option[String] = None): Unit = {
-    if (stepMappings.nonEmpty) {
-      val json = Serialization.write(
-        PipelineStepsDefinition(
-          stepMappings.foldLeft(List[String]())((pkgs, p) => if(p._2.nonEmpty) pkgs :+ p._1 else pkgs),
-          stepMappings.values.foldLeft(List[StepDefinition]())((steps, stepList) => steps ::: stepList),
-          packageObjects
-        )
-      )
-      if (outputFile.nonEmpty) {
-        val file = new File(outputFile.get)
-        val writer = new FileWriter(file)
-        writer.write(json)
-        writer.flush()
-        writer.close()
-      } else {
-        print(json)
-      }
-    } else {
-      print("No step functions found")
-    }
-  }
-
-  private def buildPackageObjects(caseClasses: Set[String]): List[PackageObject] = {
-    import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator
-    import com.fasterxml.jackson.databind.ObjectMapper
-    import com.fasterxml.jackson.databind.JsonNode
-
-    caseClasses.map(x => {
-      val xClass = Class.forName(x)
-      val objectMapper = new ObjectMapper
-      objectMapper.registerModule(new DefaultScalaModule)
-      import com.kjetland.jackson.jsonSchema.JsonSchemaConfig
-      val config = JsonSchemaConfig.vanillaJsonSchemaDraft4
-      val jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper, debug=true, config)
-      val jsonSchema: JsonNode = jsonSchemaGenerator.generateJsonSchema(xClass)
-      val schema = objectMapper.writeValueAsString(jsonSchema).replaceFirst("draft-04", "draft-07")
-       PackageObject(x, schema)
-    }).toList
-  }
-
   /**
     * Helper function that will load an object and check for step functions. Use the @StepObject and @StepFunction
     * annotations to identify which objects and functions should be included.
@@ -134,8 +103,9 @@ object StepMetaDataExtractor {
     * @param stepObjectPath The fully qualified class name.
     * @return A list of step definitions.
     */
-  private def findStepDefinitions(stepObjectPath: String, packageName: String, jarName: String): Option[(List[StepDefinition], Set[String])] = {
+  private def findStepDefinitions(stepObjectPath: String, jarName: String): Option[(List[StepDefinition], Set[String])] = {
     val mirror = ru.runtimeMirror(getClass.getClassLoader)
+    val packageName = stepObjectPath.substring(0, stepObjectPath.lastIndexOf("."))
     Try(mirror.staticModule(stepObjectPath)) match {
       case Success(_) =>
         val module = mirror.staticModule(stepObjectPath)
@@ -166,7 +136,7 @@ object StepMetaDataExtractor {
             val parameterInfo = getParameterInfo(paramSymbol)
             val annotations = paramSymbol.annotations
             val a1 = annotations.find(_.tree.tpe =:= ru.typeOf[StepParameter])
-            val updatedStepParams = if (a1.isDefined)  {
+            val updatedStepParams = if (a1.isDefined) {
               stepParams :+ annotationToStepFunctionParameter(a1.get, paramSymbol, parameterInfo)
             } else {
               stepParams :+ StepFunctionParameter(getParameterType(paramSymbol, parameterInfo.caseClass),
@@ -180,11 +150,15 @@ object StepMetaDataExtractor {
                 parameterType = Some(parameterInfo.className))
             }
             // only add non-private case classes to the case class set
-            val updatedCaseClassSet = if(parameterInfo.caseClass && !annotations.exists(_.tree.tpe =:= ru.typeOf[PrivateObject])) {
+            val updatedCaseClassSet = if (parameterInfo.caseClass && !annotations.exists(_.tree.tpe =:= ru.typeOf[PrivateObject])) {
               paramsAndClasses._2 + parameterInfo.className
-            } else { paramsAndClasses._2 }
+            } else {
+              paramsAndClasses._2
+            }
             (updatedStepParams, updatedCaseClassSet)
-          } else { paramsAndClasses }
+          } else {
+            paramsAndClasses
+          }
         })
       } else { (List[StepFunctionParameter](), caseClasses) }
       val returnType = getReturnType(symbol.asMethod)
@@ -226,19 +200,11 @@ object StepMetaDataExtractor {
     }
   }
 
-  private def getParameterInfo(paramSymbol: ru.Symbol): ParameterInfo = {
-   if (paramSymbol.typeSignature.typeSymbol.isClass &&
-      paramSymbol.typeSignature.typeSymbol.asClass.isCaseClass) {
-     ParameterInfo(paramSymbol.typeSignature.toString, caseClass = true)
-    } else if (paramSymbol.typeSignature.toString.startsWith("Option[")) {
-     extractCaseClassFromOption(paramSymbol)
-    } else { ParameterInfo(paramSymbol.typeSignature.toString, caseClass = false) }
-  }
-
   /**
     * Determine if the BranchResults annotation exists and add the results to the parameters.
+    *
     * @param parameters The existing step parameters
-    * @param symbol The step symbol
+    * @param symbol     The step symbol
     * @return A list of parameters that may include result type parameters.
     */
   private def getBranchResults(parameters: List[StepFunctionParameter], symbol: ru.Symbol): List[StepFunctionParameter] = {
@@ -258,6 +224,7 @@ object StepMetaDataExtractor {
 
   /**
     * This function will inspect the Option type to determine if a case class is embedded.
+    *
     * @param paramSymbol The parameter symbol
     * @return A ParameterInfo that provides the classname and a boolean indicating whether this is a case class
     */
@@ -279,7 +246,8 @@ object StepMetaDataExtractor {
 
   /**
     * This function converts the step parameter annotation into a StepFunctionParameter.
-    * @param annotation The annotation to convert
+    *
+    * @param annotation  The annotation to convert
     * @param paramSymbol The parameter information
     * @return
     */
@@ -326,6 +294,17 @@ object StepMetaDataExtractor {
       })
   }
 
+  private def getParameterInfo(paramSymbol: ru.Symbol): ParameterInfo = {
+    if (paramSymbol.typeSignature.typeSymbol.isClass &&
+      paramSymbol.typeSignature.typeSymbol.asClass.isCaseClass) {
+      ParameterInfo(paramSymbol.typeSignature.toString, caseClass = true)
+    } else if (paramSymbol.typeSignature.toString.startsWith("Option[")) {
+      extractCaseClassFromOption(paramSymbol)
+    } else {
+      ParameterInfo(paramSymbol.typeSignature.toString, caseClass = false)
+    }
+  }
+
   private def isValueSet(annotationValue: String) = annotationValue.startsWith("scala.Some.apply[")
 
   private def getAnnotationValue(annotationValue: String, stringValue: Boolean): Any = {
@@ -344,12 +323,21 @@ object StepMetaDataExtractor {
         case "Option[Int]" => "integer"
         case "Option[Boolean]" => "boolean"
         case "Boolean" => "boolean"
-        case _ => if (caseClass) { "object" } else { "text" }
+        case _ => if (caseClass) {
+          "object"
+        } else {
+          "text"
+        }
       }
     } catch {
       case _: Throwable => "text"
     }
   }
 }
+
+case class StepMetadata(value: String,
+                        pkgs: List[String],
+                        steps: List[StepDefinition],
+                        pkgObjs: List[PackageObject]) extends Metadata
 
 case class ParameterInfo(className: String, caseClass: Boolean)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.acxiom</groupId>
     <artifactId>metalus</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.1-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
     <description>Metalus Pipeline Library</description>


### PR DESCRIPTION
- Created a generic metadata extractor
- Added a pipeline metadata extractor
- Added flags to metadata extractor to disable default extractors (step or pipeline)
- Enhanced PipelineManager to pull from the classpath "/metadata/pipelines"
- Fixed an issue where class constructors with default parameters failed to load.
- ApplicationUtils will now use PipelineManager to find pipelines that aren't part of the execution or contained in the application pipelines
- Marked metalus-core dependency in metalus-common as provided


